### PR TITLE
Fix customizable bower dir

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,7 +37,7 @@ gulp.task('clean:resources', function() {
 gulp.task('clean', ['clean:target', 'clean:resources']);
 
 gulp.task('bower:install', ['clean'], function() {
-  return bower({ cmd: 'install', cwd: globalVar.publicDir}, [globalVar.bowerPackages]);
+  return bower({ cmd: 'install', directory: globalVar.bowerDirCwd, cwd: globalVar.publicDir}, [globalVar.bowerPackages]);
 });
 
 gulp.task('parse', ['analyze'], function(cb) {

--- a/template/tasks/global-variables.js
+++ b/template/tasks/global-variables.js
@@ -21,7 +21,7 @@ module.exports = {
   clientDir: clientDir,
   publicDir: publicDir,
   bowerDirCwd: "./" + bowerDirName,
-  bowerDir: publicDir + +bowerDirName + "/",
+  bowerDir: publicDir + bowerDirName + "/",
   bowerPackages: (args.package || 'PolymerElements/paper-elements').split(/[, ]+/)
 };
 

--- a/template/tasks/global-variables.js
+++ b/template/tasks/global-variables.js
@@ -9,6 +9,7 @@ var publicDirBase = currentDir + (args.resourcesDir || 'src/main/resources/').re
 
 var clientDir = clientDirBase + '/' + nspath + "/";
 var publicDir = publicDirBase + '/' + nspath + "/public/";
+var bowerDirName = "bower_components";
 
 module.exports = {
   ns: ns,
@@ -19,7 +20,8 @@ module.exports = {
   publicDirBase: publicDirBase,
   clientDir: clientDir,
   publicDir: publicDir,
-  bowerDir: publicDir + "bower_components/",
+  bowerDirCwd: "./" + bowerDirName,
+  bowerDir: publicDir + +bowerDirName + "/",
   bowerPackages: (args.package || 'PolymerElements/paper-elements').split(/[, ]+/)
 };
 


### PR DESCRIPTION
Bower was previously using the default of "./bower_components"
regardless of bowerDir.

This effectively allows anyone using this to specify any directory name for bower downloads.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/gwt-api-generator/43)
<!-- Reviewable:end -->
