### PR TITLE
Add JsArray import to Event templates

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ gulp.task('bower:configure', ['clean:resources'], function(done) {
     if (!err) {
       fs.copySync('.bowerrc', globalVar.publicDir + '/.bowerrc');
       if(obj.directory) {
-        globalVar.bowerDir = globalVar.publicDir + '/' + obj.directory;
+        globalVar.bowerDir = globalVar.publicDir + '/' + obj.directory + '/';
       }
     }
     done();

--- a/template/ElementEvent.template
+++ b/template/ElementEvent.template
@@ -2,6 +2,7 @@
 package <%= ns %>.event;
 
 import com.vaadin.polymer.elemental.*;
+import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JavaScriptObject;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;

--- a/template/WidgetEvent.template
+++ b/template/WidgetEvent.template
@@ -2,6 +2,7 @@
 package <%= ns %>.widget.event;
 
 import com.google.gwt.event.dom.client.DomEvent;
+import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JavaScriptObject;
 
 /**


### PR DESCRIPTION
This is a PR to fix issue #59.

Note: Polymer/hydrolysis#212, there seems to be breaking issues with the latest version of hydrolysis.
For testing, I used v1.21.4.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/gwt-api-generator/60)
<!-- Reviewable:end -->
