### PR TITLE
Fix Show Case link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ in a GWT application.
 
 Build script, demo and usage instructions for the project are available [here](https://github.com/vaadin/gwt-polymer-elements).
 
-You also might see all these components in action using the [Show Case](http://vaadin.github.io/gwt-polymer-elements/demo/) application
+You also might see all these components in action using the [Show Case](http://manolo.github.io/gwt-polymer-elements/demo/) application
 
 ## Using your own Web Components in your App.
 


### PR DESCRIPTION
Show Case link was pointing to Vaadin's (nonexistent) repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/manolo/gwt-api-generator/89)
<!-- Reviewable:end -->
